### PR TITLE
fixed reading NDEF tags on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,6 @@ Add those two lines to your `AndroidManifest.xml` on the top
         android:required="true" />
 ```
 
-and add this in your _.MainActivity_ just below the other **intent-filter**:
-
-```xml
-<intent-filter>
-  <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
-  <category android:name="android.intent.category.DEFAULT"/>
-  <data android:mimeType="text/plain" />
-</intent-filter>
-```
-
-**Attention** the _mimeType_ should be the right one for the [expected type](https://developer.android.com/guide/topics/connectivity/nfc/nfc) of NFC you are going to read.
-
 ### iOS Setup
 
 Atm only `Swift` based Flutter project are supported.

--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.nfc.NfcAdapter
 import android.nfc.NfcManager
 import android.nfc.Tag
+import android.nfc.tech.Ndef
 import android.os.Build
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
+import java.nio.charset.Charset
 
 class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler,  NfcAdapter.ReaderCallback {
     private var isReading = false
@@ -84,7 +86,18 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler,  Nfc
 
     // handle discovered NDEF Tags
     override fun onTagDiscovered(tag: Tag?) {
-        resulter?.success(bytesToHexString(it.id))
+        // convert tag to NDEF tag
+        val ndef = Ndef.get(tag)
+        // ndef will be null if the discovered tag is not a NDEF tag
+        // read NDEF message
+        ndef?.connect()
+        val message = ndef?.getNdefMessage()
+                          ?.toByteArray()
+                          ?.toString(Charset.forName("UTF-8"))
+        ndef?.close()
+        if (message != null) {
+            resulter?.success(message)
+        }
     }
 
     private fun bytesToHexString(src: ByteArray?): String? {

--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -18,7 +18,7 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler {
 
     private var resulter: Result? = null
 
-    private var READER_FLAGS = NfcAdapter.FLAG_READER_NFC_A or NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+    private var READER_FLAGS = NfcAdapter.FLAG_READER_NFC_A
 
     companion object {
         @JvmStatic

--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -3,6 +3,7 @@ package it.matteocrippa.flutternfcreader
 import android.content.Context
 import android.nfc.NfcAdapter
 import android.nfc.NfcManager
+import android.nfc.Tag
 import android.os.Build
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -10,7 +11,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler {
+class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler,  NfcAdapter.ReaderCallback {
     private var isReading = false
     private var stopOnFirstDiscovered = false
     private var nfcAdapter: NfcAdapter? = null
@@ -63,11 +64,7 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler {
         isReading = if (nfcAdapter?.isEnabled == true) {
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                nfcAdapter?.enableReaderMode(registrar.activity(), {
-
-                    resulter?.success(bytesToHexString(it.id))
-                },READER_FLAGS, null )
-
+                nfcAdapter?.enableReaderMode(registrar.activity(), this, READER_FLAGS, null )
             }
 
             true
@@ -85,6 +82,10 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler {
         isReading = false
     }
 
+    // handle discovered NDEF Tags
+    override fun onTagDiscovered(tag: Tag?) {
+        resulter?.success(bytesToHexString(it.id))
+    }
 
     private fun bytesToHexString(src: ByteArray?): String? {
         val stringBuilder = StringBuilder("0x")

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -39,11 +39,6 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <data android:mimeType="text/plain" />
-            </intent-filter>
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
The fix 45a3a2551c96dc42f29ecaf6b59a3d3111254fd4 for reading NDEF messages on Android did almost work, except that setting NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK will result in Ndef.get(tag)  always returing null. Removing the flag solves the problem. :-)

The supplied patches fix this problem and provide some code cleanup.

I tested this version on a Google Pixel (1) and did not encounter any problems so far.