### PR TITLE
use stream to be able to read nfc details without interruptions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 18
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_nfc_reader/flutter_nfc_reader.dart';
 
@@ -20,8 +20,6 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> startNFC() async {
-    NfcData response;
-
     setState(() {
       _nfcData = NfcData();
       _nfcData.status = NFCStatus.reading;
@@ -29,14 +27,11 @@ class _MyAppState extends State<MyApp> {
 
     print('NFC: Scan started');
 
-    try {
-      print('NFC: Scan readed NFC tag');
-      response = await FlutterNfcReader.read;
-    } on PlatformException {
-      print('NFC: Scan stopped exception');
-    }
-    setState(() {
-      _nfcData = response;
+    print('NFC: Scan readed NFC tag');
+    FlutterNfcReader.read.listen((response) {
+      setState(() {
+        _nfcData = response;
+      });
     });
   }
 

--- a/lib/flutter_nfc_reader.dart
+++ b/lib/flutter_nfc_reader.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 enum NFCStatus {
@@ -54,13 +55,17 @@ class NfcData {
 class FlutterNfcReader {
   static const MethodChannel _channel =
       const MethodChannel('flutter_nfc_reader');
+  static const stream =
+      const EventChannel('it.matteocrippa.flutternfcreader.flutter_nfc_reader');
 
-  static Future<NfcData> get read async {
-    final Map data = await _channel.invokeMethod('NfcRead');
-
-    final NfcData result = NfcData.fromMap(data);
-
-    return result;
+  static Stream<NfcData> get read {
+    final resultStream = _channel
+        .invokeMethod('NfcRead')
+        .asStream()
+        .asyncExpand((_) => stream
+            .receiveBroadcastStream()
+            .map((result) => NfcData.fromMap(result)));
+    return resultStream;
   }
 
   static Future<NfcData> get stop async {


### PR DESCRIPTION
Hi! 
I found a problem in your library. This issue mentioned in #26 and #8  
When you call a `startNFC` method, you could read a NFC tag only once, because a Dart `MethodChannel` doesn't allow to return multiple results.
Using `EventChannel` instead you will be able to read a values until you call `stopNFC`.