### PR TITLE
Allow more tag technologies on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ You can also trigger the stop event manually using a dedicated function.
 
 | Platform | Supported NFC Tags |
 | --- | --- |
-| Android | NDEF |
-| iOS | NDEF |
+| Android | **NDEF:**  A, B, F, V, BARCODE|
+| iOS | **NDEF:** NFC TYPE 1, 2, 3, 4, 5 |
 
 ## Installation
 

--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -35,8 +35,12 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler, Even
     private var kError = "nfcError"
     private var kStatus = "nfcStatus"
 
-    private var READER_FLAGS = NfcAdapter.FLAG_READER_NFC_A
-
+    private var READER_FLAGS = NfcAdapter.FLAG_READER_NFC_A or
+            NfcAdapter.FLAG_READER_NFC_B or
+            NfcAdapter.FLAG_READER_NFC_BARCODE or
+            NfcAdapter.FLAG_READER_NFC_F or
+            NfcAdapter.FLAG_READER_NFC_V
+            
     companion object {
         @JvmStatic
         fun registerWith(registrar: Registrar): Unit {


### PR DESCRIPTION
This adds support for technologies other than NFC-A on Android, which will make the plugin work for a lot more RFID-tags.