### PR TITLE
changed CoreNFC to be a weak framework

### DIFF
--- a/ios/flutter_nfc_reader.podspec
+++ b/ios/flutter_nfc_reader.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.frameworks = 'CoreNFC'
+  s.weak_frameworks = 'CoreNFC'
   s.swift_version = '4.0'
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
Currently Apps using this Plugin will not run on iPads, as the CoreNFC framework is currently not available on any iPad. Changing the requirement of CoreNFC to weak framework enables this apps to run even if the framework is not available.