### PR TITLE
Uses UIThread on Android when using channel

### DIFF
--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -133,7 +133,9 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler, Even
         ndef?.close()
         if (message != null) {
             val data = mapOf(kId to id, kContent to message, kError to "", kStatus to "read")
-            eventSink?.success(data)
+            Handler(Looper.getMainLooper()).post {
+                eventSink?.success(data)
+            }
         }
     }
 

--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -7,6 +7,8 @@ import android.nfc.NfcManager
 import android.nfc.Tag
 import android.nfc.tech.Ndef
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.EventChannel.StreamHandler
 import io.flutter.plugin.common.EventChannel.EventSink
@@ -16,6 +18,9 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.nio.charset.Charset
+import java.lang.Runnable
+
+
 
 
 const val PERMISSION_NFC = 1007
@@ -133,9 +138,9 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler, Even
         ndef?.close()
         if (message != null) {
             val data = mapOf(kId to id, kContent to message, kError to "", kStatus to "read")
-            Handler(Looper.getMainLooper()).post {
+            Handler(Looper.getMainLooper()).post(Runnable {
                 eventSink?.success(data)
-            }
+            })
         }
     }
 


### PR DESCRIPTION
Looks like after flutter 1.6 you need to jump back to the UIThread before sending messages over a channel
More info here: https://flutter.dev/docs/development/platform-integration/platform-channels#jumping-to-the-ui-thread-in-android

Since I don't own any ios devices, I can't test if the changes made to flutter 1.6 broke this plugin for ios as well. But since there is a chapter for making the switch to the main thread on ios as well, I would assume so. More info here: https://flutter.dev/docs/development/platform-integration/platform-channels#jumping-to-the-main-thread-in-ios