### PR TITLE
Develop

### DIFF
--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -7,6 +7,7 @@ import android.nfc.NfcManager
 import android.nfc.Tag
 import android.nfc.tech.Ndef
 import android.os.Build
+import android.os.Handler
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.EventChannel.StreamHandler
 import io.flutter.plugin.common.EventChannel.EventSink
@@ -16,6 +17,9 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.nio.charset.Charset
+import android.os.Looper
+
+
 
 
 const val PERMISSION_NFC = 1007
@@ -133,7 +137,10 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler, Even
         ndef?.close()
         if (message != null) {
             val data = mapOf(kId to id, kContent to message, kError to "", kStatus to "read")
-            eventSink?.success(data)
+            val mainHandler = Handler(Looper.getMainLooper())
+            mainHandler.post {
+                eventSink?.success(data)
+            }
         }
     }
 

--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/FlutterNfcReaderPlugin.kt
@@ -125,8 +125,8 @@ class FlutterNfcReaderPlugin(val registrar: Registrar) : MethodCallHandler, Even
         // ndef will be null if the discovered tag is not a NDEF tag
         // read NDEF message
         ndef?.connect()
-        val message = ndef?.ndefMessage
-                          ?.toByteArray()
+        val ndefMessage = ndef?.ndefMessage ?: ndef?.cachedNdefMessage
+        val message = ndefMessage?.toByteArray()
                           ?.toString(Charset.forName("UTF-8")) ?: ""
         //val id = tag?.id?.toString(Charset.forName("ISO-8859-1")) ?: ""
         val id = bytesToHexString(tag?.id) ?: ""

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_nfc_reader
 description: A nfc reader plugin for iOS and Android. This plugin allow you to trigger NFC native reading session on device.
-version: 0.0.23
-author: Matteo Crippa <matteocrippa>
-homepage: https://github.com/matteocrippa/flutter-nfc-reader
+version: 0.0.49
+author: Alexander Deutsch, original forked from Matteo Crippa <matteocrippa>
+homepage: https://github.com/f1re/flutter-nfc-reader
 
 environment:
   sdk: '>=1.19.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_nfc_reader
 description: A nfc reader plugin for iOS and Android. This plugin allow you to trigger NFC native reading session on device.
-version: 0.0.49
-author: Alexander Deutsch, original forked from Matteo Crippa <matteocrippa>
-homepage: https://github.com/f1re/flutter-nfc-reader
+version: 0.0.23
+author: Matteo Crippa <matteocrippa>
+homepage: https://github.com/matteocrippa/flutter-nfc-reader
 
 environment:
   sdk: '>=1.19.0 <3.0.0'


### PR DESCRIPTION
This PR contains 3 bug fixes:
- Foreground NFC Reading from iOS was not working and is fixed, problem was the according eventchannel was not created and used
- "not on UIMainThread" crash on android with latest flutter is fixed
- Fix problem when just holding the phone very briefly on a nfc tag. Problem was, the implementation was always trying to initiate a connection to the tag, which failed when it was too short. Fix is to then just take the last read value instead of establishing the connection