### PR TITLE
Implement the instruction parameter for iOS again

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ use_frameworks!
 This function will return a promise when a read occurs, till that very moment the reading session is open.
 The promise will return a `NfcData` model, this model contains:
 
+`FlutterNfcReader.read()` has an optional parameter, only for **iOS**, called `instruction`.
+You can pass a _String_ that contains information to be shown in the modal screen.
+
 - id > id of the tag
 - content > content of the tag
 - error > if any error occurs

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ use_frameworks!
 This function will return a promise when a read occurs, till that very moment the reading session is open.
 The promise will return a `NfcData` model, this model contains:
 
-`FlutterNfcReader.read()` has an optional parameter, only for **iOS**, called `instruction`.
+`FlutterNfcReader.read()` and `FlutterNfcReader.onTagDiscovered()` have an optional parameter, only for **iOS**, called `instruction`.
 You can pass a _String_ that contains information to be shown in the modal screen.
 
 - id > id of the tag

--- a/lib/flutter_nfc_reader.dart
+++ b/lib/flutter_nfc_reader.dart
@@ -74,9 +74,11 @@ class FlutterNfcReader {
     return result;
   }
 
-  static Stream<NfcData> onTagDiscovered() {
+  static Stream<NfcData> onTagDiscovered({instruction: String}) {
     if (Platform.isIOS) {
-      _channel.invokeMethod('NfcRead');
+      _channel.invokeMethod('NfcRead', {
+        "instruction": instruction
+      });
     }
     return stream.receiveBroadcastStream().map((rawNfcData) {
       return NfcData.fromMap(rawNfcData);

--- a/lib/flutter_nfc_reader.dart
+++ b/lib/flutter_nfc_reader.dart
@@ -66,10 +66,11 @@ class FlutterNfcReader {
     return result;
   }
 
-  static Future<NfcData> read() async {
-    final Map data = await _channel.invokeMethod('NfcRead');
+  static Future<NfcData> read({instruction: String}) async {
+    final Map data = await _channel.invokeMethod('NfcRead', {
+      "instruction": instruction
+    });
     final NfcData result = NfcData.fromMap(data);
-
     return result;
   }
 


### PR DESCRIPTION
Even if the native Swift code still contains code for receiving and alertMessage from Flutter there is no way of actually using it in the library's Dart code. I couldn't find any reason for removing this in the commit which removed it so I added it again