### PR TITLE
Fix exception when checking NFCavailability on phones without NFC

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/lib/flutter_nfc_reader.dart
+++ b/lib/flutter_nfc_reader.dart
@@ -73,12 +73,7 @@ class FlutterNfcReader {
     return result;
   }
 
-  static Future<NfcData> stop() async {
-    final Map data = await _channel.invokeMethod('NfcStop');
-    final NfcData result = NfcData.fromMap(data);
-
-    return result;
-  }
+  static Future<void> stop() => _channel.invokeMethod('NfcStop');
 
   static Future<NfcData> read({String instruction}) async {
     final Map data = await _callRead(instruction: instruction);


### PR DESCRIPTION
Currently we always throw an exception when there is no NFCAdapter even when calling "NfcAvailability" which does not always need a nfc adapter, which doesn't allow apps to check whether the phone supports NFC or not