### PR TITLE
Fix null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Matteo Crippa <matteocrippa>
 homepage: https://github.com/matteocrippa/flutter-nfc-reader
 
 environment:
-  sdk: ">=2.12.0-29.10.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ^1.22.0
 
 dependencies:


### PR DESCRIPTION
PR is suppose to fix an issue mentioned here 
https://github.com/matteocrippa/flutter-nfc-reader/issues/93

The problem was that pre-release version of dart were used and new tools didn't recognised it as nullsafety-compatible